### PR TITLE
ドリンク履歴の削除機能を実装

### DIFF
--- a/backend/app/controllers/customs_controller.rb
+++ b/backend/app/controllers/customs_controller.rb
@@ -1,4 +1,5 @@
 class CustomsController < ApplicationController
+    
     # カスタム画面にカスタムをセットするメソッド
     def showCustom
         # パラメータからuser_idを取得

--- a/backend/app/controllers/drink_controller.rb
+++ b/backend/app/controllers/drink_controller.rb
@@ -158,6 +158,7 @@ class DrinkController < ApplicationController
         # 取れた値をフロントエンドに返す
         render json: { 栄養APIのデータ: real_drink}
     end
+
     # *******************************************************************
     
     def show
@@ -183,14 +184,6 @@ class DrinkController < ApplicationController
         end
     end
 
-    # *******************************************************************
-
-
-
-    # *******************************************************************
-
- 
-    
     # *******************************************************************
 
     def drink_history
@@ -223,20 +216,21 @@ class DrinkController < ApplicationController
 
         render json: drinks_data  
     end  
-    
-    # *******************************************************************
-
-
-    
-    # *******************************************************************
-    
- 
-    
-    # *******************************************************************
-
-
 
     # *******************************************************************
 
+    # ドリンクの履歴を削除するメソッド
+    def destroy
+        drink_result_log = DrinkResultLog.find_by(id: params[:id])
+    
+        if drink_result_log
+          drink_result_log.destroy
+          render json: { message: "Drink deleted successfully" }, status: :ok
+        else
+          render json: { error: "Drink not found" }, status: :not_found
+        end
+      rescue ActiveRecord::RecordNotDestroyed => e
+        render json: { error: e.message }, status: :unprocessable_entity
+      end    
 
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,34 +1,43 @@
 Rails.application.routes.draw do
-  # drinkコントローラのcreateアクションへのルーティング
-  post 'drink/:user_id', to: 'drink#create'
+
+  #####drinkコントローラ#####
+    # drinkコントローラのcreateアクションへのルーティング
+    post 'drink/:user_id', to: 'drink#create'
   
-  # drinkコントローラのshowアクションへのルーティング
-  get 'drink/:user_id', to: 'drink#show'
+    # drinkコントローラのshowアクションへのルーティング
+    get 'drink/:user_id', to: 'drink#show'
 
-  # drinkコントローラのshowアクションへのルーティング
-  get 'custom/:user_id', to: 'customs#showCustom'  
+    # 新しいAPIエンドポイントのルート設定
+    get 'drinks/history/:user_id', to: 'drink#drink_history'  
+    
+    # ドリンク履歴削除のためのルーティング
+    delete 'drinks/:id', to: 'drink#destroy'
 
-  # DrinksControllerに対する新しいルートを追加
-  post 'drinks/update_drink_result/:user_id', to: 'customs#update_drink_result'
+  #####customsコントローラ#####
+    # drinkコントローラのshowアクションへのルーティング
+    get 'custom/:user_id', to: 'customs#showCustom'  
 
-  # 新しいAPIエンドポイントのルート設定
-  get 'drinks/history/:user_id', to: 'drink#drink_history'  
+    # DrinksControllerに対する新しいルートを追加
+    post 'drinks/update_drink_result/:user_id', to: 'customs#update_drink_result'
 
-  # 履歴画面からカスタム画面に飛ぶときにカスタムをDBから取得する際
-  get 'drinks/:id', to: 'customs#showCustomFromHistory'  
+    # 履歴画面からカスタム画面に飛ぶときにカスタムをDBから取得する際
+    get 'drinks/:id', to: 'customs#showCustomFromHistory'  
 
-  # ドリンクのカスタム情報を更新するためのルーティング
-  post 'drinks/update/:id', to: 'customs#update_custom'
+    # ドリンクのカスタム情報を更新するためのルーティング
+    post 'drinks/update/:id', to: 'customs#update_custom'
+  
+  #####commentコントローラ#####
+    # ドリンクのコメントを編集するためのルーティング
+    get 'comment/:id', to: 'comment#show_comment'
 
-  # ドリンクのコメントを編集するためのルーティング
-  get 'comment/:id', to: 'comment#show_comment'
+    # ドリンクのコメントを更新するためのルーティング
+    post 'update_comment/:id', to: 'comment#update_comment'
 
-  # ドリンクのコメントを更新するためのルーティング
-  post 'update_comment/:id', to: 'comment#update_comment'
+  #####usersコントローラ#####
+    # サインアップ時のルーティング
+    post 'signup', to: 'users#create'
 
-  # サインアップ時のルーティング
-  post 'signup', to: 'users#create'
+    # メールアドレスからユーザIDを取得するためのルーティング
+    get 'find_user_id', to: 'users#find_user_id'  
 
-  # メールアドレスからユーザIDを取得するためのルーティング
-  get 'find_user_id', to: 'users#find_user_id'  
 end

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,39 +1,44 @@
 # ---- Base Node ----
-FROM node:18-alpine AS base
-# コンテナ内の作業ディレクトリ
-WORKDIR /usr/src/app
-
-# Copy package.json and yarn.lock for utilising Docker cache 
-# package.jsonとyarn.lockファイルをルートディレクトリ配下にコピーする。
-COPY package.json yarn.lock ./
-
-# ---- Dependencies ----
-FROM base AS dependencies  
-# 後半でyarnのキャッシュを削除して軽くしている。
-RUN yarn install && yarn cache clean
-
-# ---- Copy Files/Build ----
-# ベースイメージとしてdependenciesを使用し、このビルドステージをbuildとして設定
-FROM dependencies AS build 
-# Dockerイメージ内の作業ディレクトリを/usr/src/appに設定
-WORKDIR /usr/src/app
-# 現在のディレクトリの内容を作業ディレクトリにコピー
-COPY . /usr/src/app
-# yarnを使用してアプリケーションをビルド
-RUN yarn build
-
-# --- Release ----
-# ベースイメージとしてbaseを使用し、このリリースステージをreleaseとして設定
-FROM base AS release
-# 依存関係ステージからnode_modulesをコピー
-COPY --from=dependencies /usr/src/app/node_modules ./node_modules
-# ビルドステージからビルド済みの.nextディレクトリをコピー
-COPY --from=build /usr/src/app/.next ./.next
-# プロジェクトのpublicディレクトリをイメージにコピー
-COPY ./public ./public
-
-# コンテナがどのポートで通信を待ち受けるか
-EXPOSE 3000
-
-# コマンドをJSON形式で記述
-CMD ["yarn", "start", "-H", "0.0.0.0"]
+    FROM node:18-alpine AS base
+    # コンテナ内の作業ディレクトリ
+    WORKDIR /usr/src/app
+    
+    # Node.jsのネイティブ依存関係ビルド用のパッケージをインストール
+    # Python とビルドツールをインストールし、Pythonのシンボリックリンクを強制的に作成
+    RUN apk add --no-cache python3 make g++ && ln -sf /usr/bin/python3 /usr/bin/python
+    
+    # Copy package.json and yarn.lock for utilising Docker cache 
+    # package.jsonとyarn.lockファイルをルートディレクトリ配下にコピーする。
+    COPY package.json yarn.lock ./
+    
+    # ---- Dependencies ----
+    FROM base AS dependencies  
+    # 後半でyarnのキャッシュを削除して軽くしている。
+    RUN yarn install && yarn cache clean
+    
+    # ---- Copy Files/Build ----
+    # ベースイメージとしてdependenciesを使用し、このビルドステージをbuildとして設定
+    FROM dependencies AS build 
+    # Dockerイメージ内の作業ディレクトリを/usr/src/appに設定
+    WORKDIR /usr/src/app
+    # 現在のディレクトリの内容を作業ディレクトリにコピー
+    COPY . /usr/src/app
+    # yarnを使用してアプリケーションをビルド
+    RUN yarn build
+    
+    # --- Release ----
+    # ベースイメージとしてbaseを使用し、このリリースステージをreleaseとして設定
+    FROM base AS release
+    # 依存関係ステージからnode_modulesをコピー
+    COPY --from=dependencies /usr/src/app/node_modules ./node_modules
+    # ビルドステージからビルド済みの.nextディレクトリをコピー
+    COPY --from=build /usr/src/app/.next ./.next
+    # プロジェクトのpublicディレクトリをイメージにコピー
+    COPY ./public ./public
+    
+    # コンテナがどのポートで通信を待ち受けるか
+    EXPOSE 3000
+    
+    # コマンドをJSON形式で記述
+    CMD ["yarn", "start", "-H", "0.0.0.0"]
+    

--- a/frontend/src/pages/History.tsx
+++ b/frontend/src/pages/History.tsx
@@ -1,7 +1,6 @@
 import { Header } from "@/components/Header";
 import { TitleHistory } from "@/components/TitleHistory";
 import { Footer } from "@/components/Footer";
-
 import styled from 'styled-components';
 import {
     ChakraProvider,
@@ -13,12 +12,20 @@ import {
     HStack,
     Box,
     Badge,
-    Link as ChakraLink
+    IconButton,
+    AlertDialog,
+    AlertDialogBody,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogContent,
+    AlertDialogOverlay,
+    useDisclosure
 } from '@chakra-ui/react';
 import Link from 'next/link';
 import axios from 'axios';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { useAuth } from '@/contexts/AuthProvider';
+import { CloseIcon } from '@chakra-ui/icons';
 
 interface Drink {
     id: string;
@@ -35,7 +42,9 @@ interface Drink {
 const History = () => {
     const [drinks, setDrinks] = useState<Drink[]>([]);
     const { userId } = useAuth();
-    console.log(userId);     
+    const { isOpen, onOpen, onClose } = useDisclosure();
+    const [deleteId, setDeleteId] = useState<string | null>(null);
+    const cancelRef = useRef<HTMLButtonElement>(null);
 
     useEffect(() => {
         const fetchDrinks = async () => {
@@ -48,7 +57,19 @@ const History = () => {
         };
 
         fetchDrinks();
-    }, []);
+    }, [userId]);
+
+    const handleDelete = async () => {
+        if (deleteId) {
+            try {
+                await axios.delete(`http://localhost:3000/drinks/${deleteId}`);
+                setDrinks(drinks.filter(drink => drink.id !== deleteId));
+                onClose(); // 削除ダイアログを閉じる
+            } catch (error) {
+                console.error('削除に失敗しました:', error);
+            }
+        }
+    };
 
     return (
         <>
@@ -62,40 +83,77 @@ const History = () => {
                 <TitleHistory />
                 <Flex wrap="wrap" justifyContent="space-around">
                     {drinks.map(drink => (
-                        <HStack key={drink.id} p="5" m="2" boxShadow="base" align="center" spacing="5">
-                            <VStack>
-                                <Image src={`https://product.starbucks.co.jp${drink.image}`} boxSize="150px" alt="商品画像"/>
-                                <Text fontSize="lg">{drink.name}({drink.size})</Text>
-                                <Box>
-                                    <Badge colorScheme="green">カロリー: {drink.calories}</Badge>
-                                    <Badge ml="2" colorScheme="blue">タンパク質: {drink.protein}</Badge>
-                                </Box>
-                                <Box textAlign="left" >
-                                {drink.customs && drink.customs.map((custom, index) => (
-                                    <Text key={index}>・{custom}</Text>
-                                ))}
-                                </Box>
-                                <Link href={`/CustomFromHistory/${drink.id}`} passHref>
+                        <Box position="relative" key={drink.id} p="5" m="2" boxShadow="base">
+                            <IconButton
+                                aria-label="Delete drink"
+                                icon={<CloseIcon />}
+                                colorScheme="gray"
+                                position="absolute"
+                                top="1"
+                                right="1"
+                                borderRadius="full" // Make the button round
+                                size="sm" 
+                                onClick={() => { setDeleteId(drink.id); onOpen(); }}
+                            />
+                            <HStack align="center" spacing="5">
+                                <VStack>
+                                    <Image src={`https://product.starbucks.co.jp${drink.image}`} boxSize="150px" alt="商品画像"/>
+                                    <Text fontSize="lg">{drink.name}({drink.size})</Text>
+                                    <Box>
+                                        <Badge colorScheme="green">カロリー: {drink.calories}</Badge>
+                                        <Badge ml="2" colorScheme="blue">タンパク質: {drink.protein}</Badge>
+                                    </Box>
+                                    <Box textAlign="left">
+                                        {drink.customs && drink.customs.map((custom, index) => (
+                                            <Text key={index}>・{custom}</Text>
+                                        ))}
+                                    </Box>
+                                    <Link href={`/CustomFromHistory/${drink.id}`} passHref>
                                         <Button as="a" colorScheme="blue">カスタム編集</Button>
-                                </Link>
-                            </VStack>
-                            <VStack align="start" width="100%" maxW="600px">
-                                <Text fontSize="md" fontStyle="italic" >商品説明: {drink.description}</Text>
-                                {drink.comments && <Text fontSize="md" fontStyle="italic" >コメント: {drink.comments}</Text>}
-                                <HStack spacing="10" align="right">
-                                    <Link href={`/CommentEdit/${drink.id}`} passHref>
-                                        <Button as="a" colorScheme="green">コメント編集</Button>
-                                    </Link>                                    
-                                </HStack>
-                            </VStack>
-                        </HStack>
+                                    </Link>
+                                </VStack>
+                                <VStack align="start" width="100%" maxW="600px">
+                                    <Text fontSize="md" fontStyle="italic">商品説明: {drink.description}</Text>
+                                    {drink.comments && <Text fontSize="md" fontStyle="italic">コメント: {drink.comments}</Text>}
+                                    <HStack spacing="10" align="right">
+                                        <Link href={`/CommentEdit/${drink.id}`} passHref>
+                                            <Button as="a" colorScheme="green">コメント編集</Button>
+                                        </Link>
+                                    </HStack>
+                                </VStack>
+                            </HStack>
+                        </Box>
                     ))}
                 </Flex>
+                <AlertDialog
+                    isOpen={isOpen}
+                    leastDestructiveRef={cancelRef}
+                    onClose={onClose}
+                >
+                    <AlertDialogOverlay>
+                        <AlertDialogContent>
+                            <AlertDialogHeader fontSize="lg" fontWeight="bold">
+                                ドリンク削除確認
+                            </AlertDialogHeader>
+                            <AlertDialogBody>
+                                このドリンクを削除してもよろしいですか？
+                            </AlertDialogBody>
+                            <AlertDialogFooter>
+                                <Button ref={cancelRef} onClick={onClose}>
+                                    キャンセル
+                                </Button>
+                                <Button colorScheme="red" onClick={handleDelete} ml={3}>
+                                    削除
+                                </Button>
+                            </AlertDialogFooter>
+                        </AlertDialogContent>
+                    </AlertDialogOverlay>
+                </AlertDialog>
             </ChakraProvider>
             <Footer />
         </>
     );
-}
+};
 
 const StyledFlex = styled(Flex)`
     justify-content: space-between;

--- a/frontend/src/pages/Result.tsx
+++ b/frontend/src/pages/Result.tsx
@@ -34,7 +34,7 @@ const Result = () => {
     const router = useRouter();
 
     const { userId } = useAuth();
-    console.log(userId); 
+    console.log(userId);
 
     useEffect(() => {
         const apiUrl = `http://localhost:3000/drink/${userId}`;
@@ -49,7 +49,7 @@ const Result = () => {
         };
 
         fetchResultData();
-    }, []);
+    }, [userId]);
 
     const handleDrinkThis = async () => {
         try {
@@ -65,7 +65,7 @@ const Result = () => {
         } catch (error) {
             console.error("フラグの更新に失敗しました。", error);
         }
-    };    
+    };
 
     if (!resultData) {
         return <div>Loading...</div>;
@@ -121,6 +121,7 @@ const Result = () => {
 
 export default Result;
 
-function removeHtmlTags(text: string): string {
+function removeHtmlTags(text: string | null): string {
+    if (!text) return '';
     return text.replace(/<[^>]*>?/gm, '');
 }


### PR DESCRIPTION
## やったこと
* ドリンク履歴に削除機能を追加
## やらないこと
* なし
## 課題
* 「×」ボタンを右肩に表示させたところ
* リレーションを利用してドリンクに紐付くカスタムも削除しているところ(models/custom_drank_log.rb)
* 削除を実行する前に書くにするポップアップを表示させているところ
## できるようになること（ユーザ目線）
* ドリンク履歴の削除
## できなくなること（ユーザ目線）
* なし
## 動作確認
* 履歴に表示されているドリンクのカードを削除して、DBからも削除されていること
## 本番反映手順
* なし
## その他
* なし
## 画面の画像など
<img width="1440" alt="スクリーンショット 2024-05-09 22 49 13" src="https://github.com/kazuma1227rinrin/One-Drink/assets/153419621/5b8c2999-51d2-4941-b9ef-794936f60059">
<img width="1440" alt="スクリーンショット 2024-05-09 22 50 38" src="https://github.com/kazuma1227rinrin/One-Drink/assets/153419621/154066ce-94ee-44da-93a4-bec9bc794642">
